### PR TITLE
Implement per-session CSRF token

### DIFF
--- a/server/auth/sessions/app.ts
+++ b/server/auth/sessions/app.ts
@@ -27,6 +27,12 @@ export const SESSION_COOKIE_EXPIRES =
 export const COOKIE_DOMAIN =
     "." + new URL(config.getRawConfig().app.dashboard_url).hostname;
 
+export const CSRF_COOKIE_NAME = "p_csrf";
+
+export function generateCsrfToken(): string {
+    return generateSessionToken();
+}
+
 export function generateSessionToken(): string {
     const bytes = new Uint8Array(20);
     crypto.getRandomValues(bytes);
@@ -144,6 +150,26 @@ export function createBlankSessionTokenCookie(isSecure: boolean): string {
         return `${SESSION_COOKIE_NAME}=; HttpOnly; SameSite=Lax; Max-Age=0; Path=/; Secure; Domain=${COOKIE_DOMAIN}`;
     } else {
         return `${SESSION_COOKIE_NAME}=; HttpOnly; SameSite=Lax; Max-Age=0; Path=/;`;
+    }
+}
+
+export function serializeCsrfCookie(
+    token: string,
+    isSecure: boolean,
+    expiresAt: Date
+): string {
+    if (isSecure) {
+        return `${CSRF_COOKIE_NAME}=${token}; SameSite=Lax; Expires=${expiresAt.toUTCString()}; Path=/; Secure; Domain=${COOKIE_DOMAIN}`;
+    } else {
+        return `${CSRF_COOKIE_NAME}=${token}; SameSite=Lax; Expires=${expiresAt.toUTCString()}; Path=/;`;
+    }
+}
+
+export function createBlankCsrfCookie(isSecure: boolean): string {
+    if (isSecure) {
+        return `${CSRF_COOKIE_NAME}=; SameSite=Lax; Max-Age=0; Path=/; Secure; Domain=${COOKIE_DOMAIN}`;
+    } else {
+        return `${CSRF_COOKIE_NAME}=; SameSite=Lax; Max-Age=0; Path=/;`;
     }
 }
 

--- a/server/middlewares/csrfProtection.ts
+++ b/server/middlewares/csrfProtection.ts
@@ -1,11 +1,14 @@
 import { NextFunction, Request, Response } from "express";
+import cookie from "cookie";
 
 export function csrfProtectionMiddleware(
     req: Request,
     res: Response,
     next: NextFunction
 ) {
-    const csrfToken = req.headers["x-csrf-token"];
+    const csrfToken = req.headers["x-csrf-token"] as string | undefined;
+    const cookies = req.headers.cookie ? cookie.parse(req.headers.cookie) : {};
+    const csrfCookie = cookies["p_csrf"];
 
     // Skip CSRF check for GET requests as they should be idempotent
     if (req.method === "GET") {
@@ -13,7 +16,7 @@ export function csrfProtectionMiddleware(
         return;
     }
 
-    if (!csrfToken || csrfToken !== "x-csrf-protection") {
+    if (!csrfToken || !csrfCookie || csrfToken !== csrfCookie) {
         res.status(403).json({
             error: "CSRF token missing or invalid"
         });

--- a/server/routers/auth/login.ts
+++ b/server/routers/auth/login.ts
@@ -1,7 +1,9 @@
 import {
     createSession,
     generateSessionToken,
-    serializeSessionCookie
+    serializeSessionCookie,
+    generateCsrfToken,
+    serializeCsrfCookie
 } from "@server/auth/sessions/app";
 import { db } from "@server/db";
 import { users } from "@server/db";
@@ -142,6 +144,7 @@ export async function login(
         }
 
         const token = generateSessionToken();
+        const csrfToken = generateCsrfToken();
         const sess = await createSession(token, existingUser.userId);
         const isSecure = req.protocol === "https";
         const cookie = serializeSessionCookie(
@@ -149,8 +152,14 @@ export async function login(
             isSecure,
             new Date(sess.expiresAt)
         );
+        const csrfCookie = serializeCsrfCookie(
+            csrfToken,
+            isSecure,
+            new Date(sess.expiresAt)
+        );
 
         res.appendHeader("Set-Cookie", cookie);
+        res.appendHeader("Set-Cookie", csrfCookie);
 
         if (
             !existingUser.emailVerified &&

--- a/server/routers/auth/logout.ts
+++ b/server/routers/auth/logout.ts
@@ -5,7 +5,8 @@ import response from "@server/lib/response";
 import logger from "@server/logger";
 import {
     createBlankSessionTokenCookie,
-    invalidateSession
+    invalidateSession,
+    createBlankCsrfCookie
 } from "@server/auth/sessions/app";
 import { verifySession } from "@server/auth/sessions/verifySession";
 import config from "@server/lib/config";
@@ -39,6 +40,7 @@ export async function logout(
 
         const isSecure = req.protocol === "https";
         res.setHeader("Set-Cookie", createBlankSessionTokenCookie(isSecure));
+        res.appendHeader("Set-Cookie", createBlankCsrfCookie(isSecure));
 
         return response<null>(res, {
             data: null,

--- a/server/routers/auth/signup.ts
+++ b/server/routers/auth/signup.ts
@@ -14,7 +14,9 @@ import {
     createSession,
     generateId,
     generateSessionToken,
-    serializeSessionCookie
+    serializeSessionCookie,
+    generateCsrfToken,
+    serializeCsrfCookie
 } from "@server/auth/sessions/app";
 import config from "@server/lib/config";
 import logger from "@server/logger";
@@ -175,6 +177,7 @@ export async function signup(
         // });
 
         const token = generateSessionToken();
+        const csrfToken = generateCsrfToken();
         const sess = await createSession(token, userId);
         const isSecure = req.protocol === "https";
         const cookie = serializeSessionCookie(
@@ -182,7 +185,13 @@ export async function signup(
             isSecure,
             new Date(sess.expiresAt)
         );
+        const csrfCookie = serializeCsrfCookie(
+            csrfToken,
+            isSecure,
+            new Date(sess.expiresAt)
+        );
         res.appendHeader("Set-Cookie", cookie);
+        res.appendHeader("Set-Cookie", csrfCookie);
 
         if (config.getRawConfig().flags?.require_email_verification) {
             sendEmailVerificationCode(email, userId);

--- a/server/routers/idp/validateOidcCallback.ts
+++ b/server/routers/idp/validateOidcCallback.ts
@@ -25,7 +25,9 @@ import {
     createSession,
     generateId,
     generateSessionToken,
-    serializeSessionCookie
+    serializeSessionCookie,
+    generateCsrfToken,
+    serializeCsrfCookie
 } from "@server/auth/sessions/app";
 import { decrypt } from "@server/lib/crypto";
 import { UserType } from "@server/types/UserTypes";
@@ -407,6 +409,7 @@ export async function validateOidcCallback(
             });
 
             const token = generateSessionToken();
+            const csrfToken = generateCsrfToken();
             const sess = await createSession(token, existingUserId!);
             const isSecure = req.protocol === "https";
             const cookie = serializeSessionCookie(
@@ -414,8 +417,14 @@ export async function validateOidcCallback(
                 isSecure,
                 new Date(sess.expiresAt)
             );
+            const csrfCookie = serializeCsrfCookie(
+                csrfToken,
+                isSecure,
+                new Date(sess.expiresAt)
+            );
 
             res.appendHeader("Set-Cookie", cookie);
+            res.appendHeader("Set-Cookie", csrfCookie);
 
             return response<ValidateOidcUrlCallbackResponse>(res, {
                 data: {
@@ -437,6 +446,7 @@ export async function validateOidcCallback(
             }
 
             const token = generateSessionToken();
+            const csrfToken = generateCsrfToken();
             const sess = await createSession(token, existingUser.userId);
             const isSecure = req.protocol === "https";
             const cookie = serializeSessionCookie(
@@ -444,8 +454,14 @@ export async function validateOidcCallback(
                 isSecure,
                 new Date(sess.expiresAt)
             );
+            const csrfCookie = serializeCsrfCookie(
+                csrfToken,
+                isSecure,
+                new Date(sess.expiresAt)
+            );
 
             res.appendHeader("Set-Cookie", cookie);
+            res.appendHeader("Set-Cookie", csrfCookie);
 
             return response<ValidateOidcUrlCallbackResponse>(res, {
                 data: {

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,6 +1,14 @@
 import { Env } from "@app/lib/types/env";
 import axios, { AxiosInstance } from "axios";
 
+function getCsrfCookie() {
+    if (typeof document === "undefined") {
+        return undefined;
+    }
+    const match = document.cookie.match(/(?:^|; )p_csrf=([^;]+)/);
+    return match ? decodeURIComponent(match[1]) : undefined;
+}
+
 let apiInstance: AxiosInstance | null = null;
 
 export function createApiClient({ env }: { env: Env }): AxiosInstance {
@@ -33,9 +41,16 @@ export function createApiClient({ env }: { env: Env }): AxiosInstance {
         baseURL,
         timeout: 10000,
         headers: {
-            "Content-Type": "application/json",
-            "X-CSRF-Token": "x-csrf-protection"
+            "Content-Type": "application/json"
         }
+    });
+
+    apiInstance.interceptors.request.use((config) => {
+        const token = getCsrfCookie();
+        if (token) {
+            (config.headers as any)["X-CSRF-Token"] = token;
+        }
+        return config;
     });
 
     return apiInstance;


### PR DESCRIPTION
## Summary
- generate a CSRF token for each session and expose cookie helpers
- send and remove the CSRF cookie in auth flows
- read the CSRF cookie in the browser and send it via `X-CSRF-Token`
- check header and cookie value in the CSRF middleware

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_6860cb936f0c8331906432db99b577e7