### PR TITLE
Restrict default CORS origins

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -23,6 +23,13 @@ server:
         id: "P-Access-Token-Id"
         token: "P-Access-Token"
     resource_session_request_param: "p_session_request"
+    # Allowed origins for CORS requests. If not set, defaults to the
+    # dashboard_url above.
+    cors:
+        origins: ["http://localhost:3002"]
+        methods: ["GET", "POST", "PUT", "DELETE", "PATCH"]
+        allowed_headers: ["X-CSRF-Token", "Content-Type"]
+        credentials: false
 
 traefik:
     http_entrypoint: "web"

--- a/server/apiServer.ts
+++ b/server/apiServer.ts
@@ -25,15 +25,10 @@ export function createApiServer() {
     }
 
     const corsConfig = config.getRawConfig().server.cors;
+    const fallbackOrigin = config.getRawConfig().app.dashboard_url;
 
     const options = {
-        ...(corsConfig?.origins
-            ? { origin: corsConfig.origins }
-            : {
-                  origin: (origin: any, callback: any) => {
-                      callback(null, true);
-                  }
-              }),
+        origin: corsConfig?.origins ?? (fallbackOrigin ? [fallbackOrigin] : false),
         ...(corsConfig?.methods && { methods: corsConfig.methods }),
         ...(corsConfig?.allowed_headers && {
             allowedHeaders: corsConfig.allowed_headers


### PR DESCRIPTION
## Summary
- restrict CORS fallback to the dashboard URL
- document explicit CORS origins in the sample config

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6860cd83bb208331b70efe6ba39d2fd2