### PR TITLE
Remove sensitive details from logs

### DIFF
--- a/server/routers/auth/requestPasswordReset.ts
+++ b/server/routers/auth/requestPasswordReset.ts
@@ -83,9 +83,8 @@ export async function requestPasswordReset(
         const url = `${config.getRawConfig().app.dashboard_url}/auth/reset-password?email=${email}&token=${token}`;
 
         if (!config.getRawConfig().email) {
-            logger.info(
-                `Password reset requested for ${email}. Token: ${token}.`
-            );
+            // Avoid logging the reset token to prevent leakage of sensitive information
+            logger.info(`Password reset requested for ${email}.`);
         }
 
         await sendEmail(

--- a/server/routers/auth/signup.ts
+++ b/server/routers/auth/signup.ts
@@ -59,7 +59,12 @@ export async function signup(
 
     const { email, password, inviteToken, inviteId } = parsedBody.data;
 
-    logger.debug("signup", { email, password, inviteToken, inviteId });
+    // Avoid logging sensitive information such as passwords or tokens
+    logger.debug("signup request", {
+        email,
+        hasInviteToken: !!inviteToken,
+        hasInviteId: !!inviteId
+    });
 
     const passwordHash = await hashPassword(password);
     const userId = generateId(15);

--- a/server/routers/badger/verifySession.ts
+++ b/server/routers/badger/verifySession.ts
@@ -73,7 +73,8 @@ export async function verifyResourceSession(
     res: Response,
     next: NextFunction
 ): Promise<any> {
-    logger.debug("Verify session: Badger sent", req.body); // remove when done testing
+    // Log the request without including the entire body to avoid sensitive data leakage
+    logger.debug("Verify session request received");
 
     const parsedBody = verifyResourceSessionSchema.safeParse(req.body);
 

--- a/server/routers/idp/validateOidcCallback.ts
+++ b/server/routers/idp/validateOidcCallback.ts
@@ -170,9 +170,7 @@ export async function validateOidcCallback(
         );
 
         const idToken = tokens.idToken();
-        logger.debug("ID token", { idToken });
         const claims = arctic.decodeIdToken(idToken);
-        logger.debug("ID token claims", { claims });
 
         const userIdentifier = jmespath.search(
             claims,


### PR DESCRIPTION
## Summary
- avoid logging passwords or invite details during signup
- stop logging ID tokens and claims in OIDC callback handler
- don't log whole request bodies when verifying Badger sessions
- remove reset tokens from password reset logs

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsx server/routers/badger/verifySession.test.ts` *(fails: npm 403 Forbidden - registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_6860ce4311c0833199e3e7723363ea51