### PR TITLE
Validate OIDC redirect urls

### DIFF
--- a/server/lib/cleanRedirect.test.ts
+++ b/server/lib/cleanRedirect.test.ts
@@ -1,0 +1,25 @@
+import { cleanRedirect } from './cleanRedirect';
+import { assertEquals } from '@test/assert';
+
+function runTests() {
+    console.log('Running cleanRedirect tests...');
+
+    // Valid redirects
+    assertEquals(cleanRedirect('/invite?token=abc-123'), '/invite?token=abc-123', 'Invite redirect should be allowed');
+    assertEquals(cleanRedirect('/setup'), '/setup', 'Setup redirect should be allowed');
+    assertEquals(cleanRedirect('/auth/resource/42'), '/auth/resource/42', 'Resource auth redirect should be allowed');
+
+    // Invalid redirect defaults to '/'
+    assertEquals(cleanRedirect('/not/allowed'), '/', 'Unknown redirect should fall back to root');
+    assertEquals(cleanRedirect(''), '/', 'Empty redirect should fall back to root');
+    assertEquals(cleanRedirect('/invite?token='), '/', 'Malformed invite token should fall back to root');
+
+    console.log('All cleanRedirect tests passed!');
+}
+
+try {
+    runTests();
+} catch (error) {
+    console.error('Test failed:', error);
+    process.exit(1);
+}

--- a/server/lib/cleanRedirect.ts
+++ b/server/lib/cleanRedirect.ts
@@ -1,0 +1,18 @@
+type PatternConfig = {
+    name: string;
+    regex: RegExp;
+};
+
+const patterns: PatternConfig[] = [
+    { name: "Invite Token", regex: /^\/invite\?token=[a-zA-Z0-9-]+$/ },
+    { name: "Setup", regex: /^\/setup$/ },
+    { name: "Resource Auth Portal", regex: /^\/auth\/resource\/\d+$/ }
+];
+
+export function cleanRedirect(input: string, fallback: string = "/"): string {
+    if (!input || typeof input !== "string") {
+        return fallback;
+    }
+    const isAccepted = patterns.some((pattern) => pattern.regex.test(input));
+    return isAccepted ? input : fallback;
+}

--- a/server/routers/idp/generateOidcUrl.ts
+++ b/server/routers/idp/generateOidcUrl.ts
@@ -14,6 +14,7 @@ import cookie from "cookie";
 import jsonwebtoken from "jsonwebtoken";
 import config from "@server/lib/config";
 import { decrypt } from "@server/lib/crypto";
+import { cleanRedirect } from "@server/lib/cleanRedirect";
 
 const paramsSchema = z
     .object({
@@ -64,6 +65,7 @@ export async function generateOidcUrl(
         }
 
         const { redirectUrl: postAuthRedirectUrl } = parsedBody.data;
+        const safeRedirectUrl = cleanRedirect(postAuthRedirectUrl);
 
         const [existingIdp] = await db
             .select()
@@ -120,7 +122,7 @@ export async function generateOidcUrl(
 
         const stateJwt = jsonwebtoken.sign(
             {
-                redirectUrl: postAuthRedirectUrl, // TODO: validate that this is safe
+                redirectUrl: safeRedirectUrl,
                 state,
                 codeVerifier
             },


### PR DESCRIPTION
## Summary
- add cleanRedirect helper for the server
- verify redirectUrl before signing OIDC state
- test cleanRedirect logic

## Testing
- `npx tsx server/lib/cleanRedirect.test.ts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/tsx)*
- `npx tsx server/lib/ip.test.ts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/tsx)*

------
https://chatgpt.com/codex/tasks/task_b_6860cf0dd7508331ab3291cb7611a0d1