### PR TITLE
Add GUI installer module

### DIFF
--- a/install/Makefile
+++ b/install/Makefile
@@ -3,7 +3,6 @@ all: update-versions go-build-release put-back
 go-build-release:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/installer_linux_amd64
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/installer_linux_arm64
-
 clean:
 	rm -f bin/installer_linux_amd64
 	rm -f bin/installer_linux_arm64
@@ -22,3 +21,10 @@ update-versions:
 
 put-back:
 	mv main.go.bak main.go
+
+
+	gui-build-release:
+	GOOS=linux GOARCH=amd64 go build -o bin/gui_installer_linux_amd64 ./gui
+	GOOS=windows GOARCH=amd64 go build -o bin/gui_installer_windows_amd64.exe ./gui
+	GOOS=darwin GOARCH=amd64 go build -o bin/gui_installer_darwin_amd64 ./gui
+	GOOS=darwin GOARCH=arm64 go build -o bin/gui_installer_darwin_arm64 ./gui

--- a/install/go.mod
+++ b/install/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 require (
 	golang.org/x/term v0.28.0
 	gopkg.in/yaml.v3 v3.0.1
+        fyne.io/fyne/v2 v2.4.3
 )
 
 require golang.org/x/sys v0.29.0 // indirect

--- a/install/gui/config/config.yml
+++ b/install/gui/config/config.yml
@@ -1,0 +1,67 @@
+# To see all available options, please visit the docs:
+# https://docs.fossorial.io/Pangolin/Configuration/config
+
+app:
+    dashboard_url: "https://{{.DashboardDomain}}"
+    log_level: "info"
+    save_logs: false
+
+domains:
+    domain1:
+        base_domain: "{{.BaseDomain}}"
+        cert_resolver: "letsencrypt"
+
+server:
+    external_port: 3000
+    internal_port: 3001
+    next_port: 3002
+    internal_hostname: "pangolin"
+    session_cookie_name: "p_session_token"
+    resource_access_token_param: "p_token"
+    resource_access_token_headers:
+        id: "P-Access-Token-Id"
+        token: "P-Access-Token"
+    resource_session_request_param: "p_session_request"
+    secret: {{.Secret}}
+    cors:
+        origins: ["https://{{.DashboardDomain}}"]
+        methods: ["GET", "POST", "PUT", "DELETE", "PATCH"]
+        allowed_headers: ["X-CSRF-Token", "Content-Type"]
+        credentials: false
+
+traefik:
+    cert_resolver: "letsencrypt"
+    http_entrypoint: "web"
+    https_entrypoint: "websecure"
+
+gerbil:
+    start_port: 51820
+    base_endpoint: "{{.DashboardDomain}}"
+    use_subdomain: false
+    block_size: 24
+    site_block_size: 30
+    subnet_group: 100.89.137.0/20
+
+rate_limits:
+    global:
+        window_minutes: 1
+        max_requests: 500
+{{if .EnableEmail}}
+email:
+    smtp_host: "{{.EmailSMTPHost}}"
+    smtp_port: {{.EmailSMTPPort}}
+    smtp_user: "{{.EmailSMTPUser}}"
+    smtp_pass: "{{.EmailSMTPPass}}"
+    no_reply: "{{.EmailNoReply}}"
+{{end}}
+users:
+    server_admin:
+        email: "{{.AdminUserEmail}}"
+        password: "{{.AdminUserPassword}}"
+
+flags:
+    require_email_verification: {{.EnableEmail}}
+    disable_signup_without_invite: {{.DisableSignupWithoutInvite}}
+    disable_user_create_org: {{.DisableUserCreateOrg}}
+    allow_raw_resources: true
+    allow_base_domain_resources: true

--- a/install/gui/config/crowdsec/acquis.d/appsec.yaml
+++ b/install/gui/config/crowdsec/acquis.d/appsec.yaml
@@ -1,0 +1,6 @@
+listen_addr: 0.0.0.0:7422
+appsec_config: crowdsecurity/appsec-default
+name: myAppSecComponent
+source: appsec
+labels:
+  type: appsec

--- a/install/gui/config/crowdsec/acquis.d/traefik.yaml
+++ b/install/gui/config/crowdsec/acquis.d/traefik.yaml
@@ -1,0 +1,5 @@
+poll_without_inotify: false
+filenames:
+  - /var/log/traefik/*.log
+labels:
+  type: traefik

--- a/install/gui/config/crowdsec/docker-compose.yml
+++ b/install/gui/config/crowdsec/docker-compose.yml
@@ -1,0 +1,27 @@
+services:
+  crowdsec:
+    image: crowdsecurity/crowdsec:latest
+    container_name: crowdsec
+    environment:
+      GID: "1000"
+      COLLECTIONS: crowdsecurity/traefik crowdsecurity/appsec-virtual-patching crowdsecurity/appsec-generic-rules
+      ENROLL_INSTANCE_NAME: "pangolin-crowdsec"
+      PARSERS: crowdsecurity/whitelists
+      ENROLL_TAGS: docker
+    healthcheck:
+      interval: 10s
+      retries: 15
+      timeout: 10s
+      test: ["CMD", "cscli", "capi", "status"]
+    labels:
+      - "traefik.enable=false" # Disable traefik for crowdsec
+    volumes:
+      # crowdsec container data
+      - ./config/crowdsec:/etc/crowdsec # crowdsec config
+      - ./config/crowdsec/db:/var/lib/crowdsec/data # crowdsec db
+      # log bind mounts into crowdsec
+      - ./config/traefik/logs:/var/log/traefik # traefik logs
+    ports:
+      - 6060:6060 # metrics endpoint for prometheus
+    restart: unless-stopped
+    command: -t # Add test config flag to verify configuration

--- a/install/gui/config/crowdsec/dynamic_config.yml
+++ b/install/gui/config/crowdsec/dynamic_config.yml
@@ -1,0 +1,109 @@
+http:
+  middlewares:
+    redirect-to-https:
+      redirectScheme:
+        scheme: https
+    default-whitelist: # Whitelist middleware for internal IPs
+      ipWhiteList:  # Internal IP addresses
+        sourceRange:  # Internal IP addresses
+        - "10.0.0.0/8"  # Internal IP addresses
+        - "192.168.0.0/16" # Internal IP addresses
+        - "172.16.0.0/12" # Internal IP addresses
+    # Basic security headers
+    security-headers:
+      headers:
+        customResponseHeaders:  # Custom response headers
+          Server: "" # Remove server header
+          X-Powered-By: "" # Remove powered by header
+          X-Forwarded-Proto: "https"  # Set forwarded proto to https
+        sslProxyHeaders: # SSL proxy headers
+          X-Forwarded-Proto: "https" # Set forwarded proto to https
+        hostsProxyHeaders: # Hosts proxy headers
+          - "X-Forwarded-Host" # Set forwarded host
+        contentTypeNosniff: true # Prevent MIME sniffing
+        customFrameOptionsValue: "SAMEORIGIN" # Set frame options
+        referrerPolicy: "strict-origin-when-cross-origin" # Set referrer policy
+        forceSTSHeader: true # Force STS header
+        stsIncludeSubdomains: true # Include subdomains
+        stsSeconds: 63072000 # STS seconds
+        stsPreload: true # Preload STS
+    # CrowdSec configuration with proper IP forwarding
+    crowdsec:
+      plugin:
+        crowdsec:
+          enabled: true # Enable CrowdSec plugin
+          logLevel: INFO # Log level
+          updateIntervalSeconds: 15 # Update interval
+          updateMaxFailure: 0 # Update max failure
+          defaultDecisionSeconds: 15 # Default decision seconds
+          httpTimeoutSeconds: 10 # HTTP timeout
+          crowdsecMode: live # CrowdSec mode
+          crowdsecAppsecEnabled: true # Enable AppSec
+          crowdsecAppsecHost: crowdsec:7422 # CrowdSec IP address which you noted down later
+          crowdsecAppsecFailureBlock: true # Block on failure
+          crowdsecAppsecUnreachableBlock: true # Block on unreachable
+          crowdsecAppsecBodyLimit: 10485760
+          crowdsecLapiKey: "PUT_YOUR_BOUNCER_KEY_HERE_OR_IT_WILL_NOT_WORK" # CrowdSec API key which you noted down later
+          crowdsecLapiHost: crowdsec:8080 # CrowdSec  
+          crowdsecLapiScheme: http # CrowdSec API scheme
+          forwardedHeadersTrustedIPs: # Forwarded headers trusted IPs
+            - "0.0.0.0/0" # All IP addresses are trusted for forwarded headers (CHANGE MADE HERE)
+          clientTrustedIPs: # Client trusted IPs (CHANGE MADE HERE)
+            - "10.0.0.0/8" # Internal LAN IP addresses
+            - "172.16.0.0/12" # Internal LAN IP addresses
+            - "192.168.0.0/16" # Internal LAN IP addresses
+            - "100.89.137.0/20" # Internal LAN IP addresses
+
+  routers:
+    # HTTP to HTTPS redirect router
+    main-app-router-redirect:
+      rule: "Host(`{{.DashboardDomain}}`)" # Dynamic Domain Name
+      service: next-service
+      entryPoints:
+        - web
+      middlewares:
+        - redirect-to-https
+
+    # Next.js router (handles everything except API and WebSocket paths)
+    next-router:
+      rule: "Host(`{{.DashboardDomain}}`) && !PathPrefix(`/api/v1`)" # Dynamic Domain Name
+      service: next-service
+      entryPoints:
+        - websecure
+      middlewares:
+        - security-headers # Add security headers middleware
+      tls:
+        certResolver: letsencrypt
+
+    # API router (handles /api/v1 paths)
+    api-router:
+      rule: "Host(`{{.DashboardDomain}}`) && PathPrefix(`/api/v1`)" # Dynamic Domain Name
+      service: api-service
+      entryPoints:
+        - websecure
+      middlewares:
+        - security-headers # Add security headers middleware
+      tls:
+        certResolver: letsencrypt
+
+    # WebSocket router
+    ws-router:
+      rule: "Host(`{{.DashboardDomain}}`)" # Dynamic Domain Name
+      service: api-service
+      entryPoints:
+        - websecure
+      middlewares:
+        - security-headers # Add security headers middleware
+      tls:
+        certResolver: letsencrypt
+
+  services:
+    next-service:
+      loadBalancer:
+        servers:
+          - url: "http://pangolin:3002"  # Next.js server
+
+    api-service:
+      loadBalancer:
+        servers:
+          - url: "http://pangolin:3000"  # API/WebSocket server

--- a/install/gui/config/crowdsec/profiles.yaml
+++ b/install/gui/config/crowdsec/profiles.yaml
@@ -1,0 +1,25 @@
+name: captcha_remediation
+filters:
+  - Alert.Remediation == true && Alert.GetScope() == "Ip" && Alert.GetScenario() contains "http"
+decisions:
+  - type: captcha
+    duration: 4h
+on_success: break
+
+---
+name: default_ip_remediation
+filters:
+ - Alert.Remediation == true && Alert.GetScope() == "Ip"
+decisions:
+ - type: ban
+   duration: 4h
+on_success: break
+
+---
+name: default_range_remediation
+filters:
+ - Alert.Remediation == true && Alert.GetScope() == "Range"
+decisions:
+ - type: ban
+   duration: 4h
+on_success: break

--- a/install/gui/config/crowdsec/traefik_config.yml
+++ b/install/gui/config/crowdsec/traefik_config.yml
@@ -1,0 +1,91 @@
+api:
+  insecure: true
+  dashboard: true
+
+providers:
+  http:
+    endpoint: "http://pangolin:3001/api/v1/traefik-config"
+    pollInterval: "5s"
+  file:
+    filename: "/etc/traefik/dynamic_config.yml"
+
+experimental:
+  plugins:
+    badger:
+      moduleName: "github.com/fosrl/badger"
+      version: "{{.BadgerVersion}}"
+    crowdsec: # CrowdSec plugin configuration added
+      moduleName: "github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin"
+      version: "v1.4.2"
+
+log:
+  level: "INFO"
+  format: "json" # Log format changed to json for better parsing
+  maxSize: 100
+  maxBackups: 3
+  maxAge: 3
+  compress: true
+
+accessLog: # We enable access logs as json
+  filePath: "/var/log/traefik/access.log"
+  format: json
+  filters:
+    statusCodes:
+      - "200-299"  # Success codes
+      - "400-499"  # Client errors
+      - "500-599"  # Server errors
+    retryAttempts: true
+    minDuration: "100ms"  # Increased to focus on slower requests
+  bufferingSize: 100      # Add buffering for better performance
+  fields:
+    defaultMode: drop     # Start with dropping all fields
+    names:
+      ClientAddr: keep # Keep client address for IP tracking
+      ClientHost: keep  # Keep client host for IP tracking
+      RequestMethod: keep # Keep request method for tracking
+      RequestPath: keep # Keep request path for tracking
+      RequestProtocol: keep # Keep request protocol for tracking
+      DownstreamStatus: keep # Keep downstream status for tracking
+      DownstreamContentSize: keep # Keep downstream content size for tracking
+      Duration: keep # Keep request duration for tracking
+      ServiceName: keep # Keep service name for tracking
+      StartUTC: keep # Keep start time for tracking
+      TLSVersion: keep # Keep TLS version for tracking
+      TLSCipher: keep # Keep TLS cipher for tracking
+      RetryAttempts: keep # Keep retry attempts for tracking
+    headers:
+      defaultMode: drop # Start with dropping all headers
+      names:
+        User-Agent: keep # Keep user agent for tracking
+        X-Real-Ip: keep # Keep real IP for tracking
+        X-Forwarded-For: keep # Keep forwarded IP for tracking
+        X-Forwarded-Proto: keep # Keep forwarded protocol for tracking
+        Content-Type: keep # Keep content type for tracking
+        Authorization: redact  # Redact sensitive information
+        Cookie: redact        # Redact sensitive information
+
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      httpChallenge:
+        entryPoint: web
+      email: "{{.LetsEncryptEmail}}"
+      storage: "/letsencrypt/acme.json"
+      caServer: "https://acme-v02.api.letsencrypt.org/directory"
+
+entryPoints:
+  web:
+    address: ":80"
+  websecure:
+    address: ":443"
+    transport:
+      respondingTimeouts:
+        readTimeout: "30m"
+    http:
+      tls:
+        certResolver: "letsencrypt"
+      middlewares: 
+        - crowdsec@file
+
+serversTransport:
+  insecureSkipVerify: true

--- a/install/gui/config/docker-compose.yml
+++ b/install/gui/config/docker-compose.yml
@@ -1,0 +1,61 @@
+name: pangolin
+services:
+  pangolin:
+    image: fosrl/pangolin:{{.PangolinVersion}}
+    container_name: pangolin
+    restart: unless-stopped
+    volumes:
+      - ./config:/app/config
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3001/api/v1/"]
+      interval: "10s"
+      timeout: "10s"
+      retries: 15
+{{if .InstallGerbil}}
+  gerbil:
+    image: fosrl/gerbil:{{.GerbilVersion}}
+    container_name: gerbil
+    restart: unless-stopped
+    depends_on:
+      pangolin:
+        condition: service_healthy
+    command:
+      - --reachableAt=http://gerbil:3003
+      - --generateAndSaveKeyTo=/var/config/key
+      - --remoteConfig=http://pangolin:3001/api/v1/gerbil/get-config
+      - --reportBandwidthTo=http://pangolin:3001/api/v1/gerbil/receive-bandwidth
+    volumes:
+      - ./config/:/var/config
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+    ports:
+      - 51820:51820/udp
+      - 443:443 # Port for traefik because of the network_mode
+      - 80:80 # Port for traefik because of the network_mode
+{{end}}
+  traefik:
+    image: traefik:v3.4.1
+    container_name: traefik
+    restart: unless-stopped
+{{if .InstallGerbil}}
+    network_mode: service:gerbil # Ports appear on the gerbil service
+{{end}}{{if not .InstallGerbil}}
+    ports:
+      - 443:443
+      - 80:80
+{{end}}
+    depends_on:
+      pangolin:
+        condition: service_healthy
+    command:
+      - --configFile=/etc/traefik/traefik_config.yml
+    volumes:
+      - ./config/traefik:/etc/traefik:ro # Volume to store the Traefik configuration
+      - ./config/letsencrypt:/letsencrypt # Volume to store the Let's Encrypt certificates
+      - ./config/traefik/logs:/var/log/traefik # Volume to store Traefik logs
+
+networks:
+  default:
+    driver: bridge
+    name: pangolin

--- a/install/gui/config/traefik/dynamic_config.yml
+++ b/install/gui/config/traefik/dynamic_config.yml
@@ -1,0 +1,53 @@
+http:
+  middlewares:
+    redirect-to-https:
+      redirectScheme:
+        scheme: https
+
+  routers:
+    # HTTP to HTTPS redirect router
+    main-app-router-redirect:
+      rule: "Host(`{{.DashboardDomain}}`)"
+      service: next-service
+      entryPoints:
+        - web
+      middlewares:
+        - redirect-to-https
+
+    # Next.js router (handles everything except API and WebSocket paths)
+    next-router:
+      rule: "Host(`{{.DashboardDomain}}`) && !PathPrefix(`/api/v1`)"
+      service: next-service
+      entryPoints:
+        - websecure
+      tls:
+        certResolver: letsencrypt
+
+    # API router (handles /api/v1 paths)
+    api-router:
+      rule: "Host(`{{.DashboardDomain}}`) && PathPrefix(`/api/v1`)"
+      service: api-service
+      entryPoints:
+        - websecure
+      tls:
+        certResolver: letsencrypt
+
+    # WebSocket router
+    ws-router:
+      rule: "Host(`{{.DashboardDomain}}`)"
+      service: api-service
+      entryPoints:
+        - websecure
+      tls:
+        certResolver: letsencrypt
+
+  services:
+    next-service:
+      loadBalancer:
+        servers:
+          - url: "http://pangolin:3002"  # Next.js server
+
+    api-service:
+      loadBalancer:
+        servers:
+          - url: "http://pangolin:3000"  # API/WebSocket server

--- a/install/gui/config/traefik/traefik_config.yml
+++ b/install/gui/config/traefik/traefik_config.yml
@@ -1,0 +1,48 @@
+api:
+  insecure: true
+  dashboard: true
+
+providers:
+  http:
+    endpoint: "http://pangolin:3001/api/v1/traefik-config"
+    pollInterval: "5s"
+  file:
+    filename: "/etc/traefik/dynamic_config.yml"
+
+experimental:
+  plugins:
+    badger:
+      moduleName: "github.com/fosrl/badger"
+      version: "{{.BadgerVersion}}"
+
+log:
+  level: "INFO"
+  format: "common"
+  maxSize: 100
+  maxBackups: 3
+  maxAge: 3
+  compress: true
+
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      httpChallenge:
+        entryPoint: web
+      email: "{{.LetsEncryptEmail}}"
+      storage: "/letsencrypt/acme.json"
+      caServer: "https://acme-v02.api.letsencrypt.org/directory"
+
+entryPoints:
+  web:
+    address: ":80"
+  websecure:
+    address: ":443"
+    transport:
+      respondingTimeouts:
+        readTimeout: "30m"
+    http:
+      tls:
+        certResolver: "letsencrypt"
+
+serversTransport:
+  insecureSkipVerify: true

--- a/install/gui/helpers.go
+++ b/install/gui/helpers.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"io"
+	"io/fs"
+	"math/rand"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"text/template"
+	"time"
+)
+
+//go:embed config/*
+var configFiles embed.FS
+
+// loadVersions sets default component versions. Values are replaced in CI.
+func loadVersions(cfg *Config) {
+	cfg.PangolinVersion = "replaceme"
+	cfg.GerbilVersion = "replaceme"
+	cfg.BadgerVersion = "replaceme"
+}
+
+func createConfigFiles(config Config) error {
+	os.MkdirAll("config", 0755)
+	os.MkdirAll("config/letsencrypt", 0755)
+	os.MkdirAll("config/db", 0755)
+	os.MkdirAll("config/logs", 0755)
+
+	err := fs.WalkDir(configFiles, "config", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if path == "config" {
+			return nil
+		}
+		if !config.DoCrowdsecInstall && strings.Contains(path, "crowdsec") {
+			return nil
+		}
+		if config.DoCrowdsecInstall && !strings.Contains(path, "crowdsec") {
+			return nil
+		}
+		if strings.Contains(path, ".DS_Store") {
+			return nil
+		}
+		if d.IsDir() {
+			if err := os.MkdirAll(path, 0755); err != nil {
+				return fmt.Errorf("failed to create directory %s: %v", path, err)
+			}
+			return nil
+		}
+		content, err := configFiles.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read %s: %v", path, err)
+		}
+		tmpl, err := template.New(d.Name()).Parse(string(content))
+		if err != nil {
+			return fmt.Errorf("failed to parse template %s: %v", path, err)
+		}
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			return fmt.Errorf("failed to create parent directory for %s: %v", path, err)
+		}
+		outFile, err := os.Create(path)
+		if err != nil {
+			return fmt.Errorf("failed to create %s: %v", path, err)
+		}
+		defer outFile.Close()
+
+		if err := tmpl.Execute(outFile, config); err != nil {
+			return fmt.Errorf("failed to execute template %s: %v", path, err)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("error walking config files: %v", err)
+	}
+	return nil
+}
+
+func isDockerInstalled() bool {
+	cmd := exec.Command("docker", "--version")
+	return cmd.Run() == nil
+}
+
+func isUserInDockerGroup() bool {
+	if runtime.GOOS == "darwin" {
+		return true
+	}
+	if os.Geteuid() == 0 {
+		return true
+	}
+	if dockerGroup, err := user.LookupGroup("docker"); err == nil {
+		if currentUser, err := user.Current(); err == nil {
+			if ids, err := currentUser.GroupIds(); err == nil {
+				for _, id := range ids {
+					if id == dockerGroup.Gid {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+func executeDockerComposeCommandWithArgs(args ...string) error {
+	var cmd *exec.Cmd
+	var useNewStyle bool
+
+	if !isDockerInstalled() {
+		return fmt.Errorf("docker is not installed")
+	}
+
+	checkCmd := exec.Command("docker", "compose", "version")
+	if err := checkCmd.Run(); err == nil {
+		useNewStyle = true
+	} else {
+		checkCmd = exec.Command("docker-compose", "version")
+		if err := checkCmd.Run(); err == nil {
+			useNewStyle = false
+		} else {
+			return fmt.Errorf("neither 'docker compose' nor 'docker-compose' command is available")
+		}
+	}
+
+	if useNewStyle {
+		cmd = exec.Command("docker", append([]string{"compose"}, args...)...)
+	} else {
+		cmd = exec.Command("docker-compose", args...)
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func pullContainers() error {
+	fmt.Println("Pulling the container images...")
+	if err := executeDockerComposeCommandWithArgs("-f", "docker-compose.yml", "pull", "--policy", "always"); err != nil {
+		return fmt.Errorf("failed to pull the containers: %v", err)
+	}
+	return nil
+}
+
+func startContainers() error {
+	fmt.Println("Starting containers...")
+	if err := executeDockerComposeCommandWithArgs("-f", "docker-compose.yml", "up", "-d", "--force-recreate"); err != nil {
+		return fmt.Errorf("failed to start containers: %v", err)
+	}
+	return nil
+}
+
+func copyFile(src, dst string) error {
+	source, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer source.Close()
+
+	destination, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer destination.Close()
+
+	_, err = io.Copy(destination, source)
+	return err
+}
+
+func moveFile(src, dst string) error {
+	if err := copyFile(src, dst); err != nil {
+		return err
+	}
+	return os.Remove(src)
+}
+
+func generateRandomSecretKey() string {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	const length = 32
+	seededRand := rand.New(rand.NewSource(time.Now().UnixNano()))
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[seededRand.Intn(len(charset))]
+	}
+	return string(b)
+}

--- a/install/gui/main.go
+++ b/install/gui/main.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/app"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/dialog"
+	"fyne.io/fyne/v2/widget"
+)
+
+// Config mirrors the CLI installer configuration
+type Config struct {
+	PangolinVersion            string
+	GerbilVersion              string
+	BadgerVersion              string
+	BaseDomain                 string
+	DashboardDomain            string
+	LetsEncryptEmail           string
+	AdminUserEmail             string
+	AdminUserPassword          string
+	DisableSignupWithoutInvite bool
+	DisableUserCreateOrg       bool
+	EnableEmail                bool
+	EmailSMTPHost              string
+	EmailSMTPPort              int
+	EmailSMTPUser              string
+	EmailSMTPPass              string
+	EmailNoReply               string
+	InstallGerbil              bool
+	TraefikBouncerKey          string
+	DoCrowdsecInstall          bool
+	Secret                     string
+}
+
+func main() {
+	a := app.New()
+	w := a.NewWindow("Pangolin Installer")
+
+	baseDomain := widget.NewEntry()
+	dashboardDomain := widget.NewEntry()
+	letsEmail := widget.NewEntry()
+	adminEmail := widget.NewEntry()
+	adminPassword := widget.NewPasswordEntry()
+	confirmPassword := widget.NewPasswordEntry()
+	disableSignup := widget.NewCheck("", nil)
+	disableUserCreate := widget.NewCheck("", nil)
+	enableEmail := widget.NewCheck("", nil)
+	smtpHost := widget.NewEntry()
+	smtpPort := widget.NewEntry()
+	smtpUser := widget.NewEntry()
+	smtpPass := widget.NewPasswordEntry()
+	smtpNoReply := widget.NewEntry()
+	gerbilCheck := widget.NewCheck("", nil)
+	crowdsecCheck := widget.NewCheck("", nil)
+
+	form := &widget.Form{
+		Items: []*widget.FormItem{
+			widget.NewFormItem("Base Domain", baseDomain),
+			widget.NewFormItem("Dashboard Domain", dashboardDomain),
+			widget.NewFormItem("LetsEncrypt Email", letsEmail),
+			widget.NewFormItem("Admin Email", adminEmail),
+			widget.NewFormItem("Admin Password", adminPassword),
+			widget.NewFormItem("Confirm Password", confirmPassword),
+			widget.NewFormItem("Disable Signup Without Invite", disableSignup),
+			widget.NewFormItem("Disable User Create Org", disableUserCreate),
+			widget.NewFormItem("Enable Email", enableEmail),
+			widget.NewFormItem("SMTP Host", smtpHost),
+			widget.NewFormItem("SMTP Port", smtpPort),
+			widget.NewFormItem("SMTP User", smtpUser),
+			widget.NewFormItem("SMTP Password", smtpPass),
+			widget.NewFormItem("No-Reply Email", smtpNoReply),
+			widget.NewFormItem("Install Gerbil", gerbilCheck),
+			widget.NewFormItem("Install CrowdSec", crowdsecCheck),
+		},
+		OnSubmit: func() {
+			if adminPassword.Text != confirmPassword.Text {
+				dialog.ShowError(fmt.Errorf("passwords do not match"), w)
+				return
+			}
+			port, _ := strconv.Atoi(smtpPort.Text)
+			cfg := Config{
+				BaseDomain:                 baseDomain.Text,
+				DashboardDomain:            dashboardDomain.Text,
+				LetsEncryptEmail:           letsEmail.Text,
+				AdminUserEmail:             adminEmail.Text,
+				AdminUserPassword:          adminPassword.Text,
+				DisableSignupWithoutInvite: disableSignup.Checked,
+				DisableUserCreateOrg:       disableUserCreate.Checked,
+				EnableEmail:                enableEmail.Checked,
+				EmailSMTPHost:              smtpHost.Text,
+				EmailSMTPPort:              port,
+				EmailSMTPUser:              smtpUser.Text,
+				EmailSMTPPass:              smtpPass.Text,
+				EmailNoReply:               smtpNoReply.Text,
+				InstallGerbil:              gerbilCheck.Checked,
+				DoCrowdsecInstall:          crowdsecCheck.Checked,
+			}
+
+			loadVersions(&cfg)
+			cfg.Secret = generateRandomSecretKey()
+			if err := createConfigFiles(cfg); err != nil {
+				dialog.ShowError(err, w)
+				return
+			}
+			if err := moveFile("config/docker-compose.yml", "docker-compose.yml"); err != nil {
+				dialog.ShowError(err, w)
+				return
+			}
+			if err := pullContainers(); err != nil {
+				dialog.ShowError(err, w)
+				return
+			}
+			if err := startContainers(); err != nil {
+				dialog.ShowError(err, w)
+				return
+			}
+			dialog.ShowInformation("Success", "Installation complete", w)
+		},
+	}
+
+	w.SetContent(container.NewVScroll(form))
+	w.Resize(fyne.NewSize(500, 600))
+	w.ShowAndRun()
+}


### PR DESCRIPTION
## Summary
- add Fyne-based GUI installer under `install/gui`
- copy configuration templates for GUI bundle
- expose helper functions for GUI install
- cross-compile GUI binaries via Makefile
- include fyne dependency

## Testing
- `go build ./...` *(fails: missing go.sum entries)*
- `npm test` *(fails: `Missing script: "test"`)*

------
https://chatgpt.com/codex/tasks/task_b_6860d043e83c8331a98200b9d313b7fc